### PR TITLE
Use env in the hashbang

### DIFF
--- a/domainr
+++ b/domainr
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from sys import argv
 from httplib import HTTPConnection


### PR DESCRIPTION
In most cases users won't have to modify the hashbang (this is basically the equivalent of using `which`).
